### PR TITLE
Add .env support for bot using Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,24 @@ $ npm start
 ```
 
 ## Deploying
-// TODO
+
+You can run the bot locally using Docker.
+
+1. Create `.env` using `create-env.sh`
+
+    ```bash
+    chmod +x ./create-env.sh
+    bash ./create-env.sh
+    ```
+
+2. Run the bot with Docker Compose. `--build` is to be used when there are changes made to the bot and you want them to
+   be reflected.
+
+    ```bash
+    docker-compose up [--build]
+    ```
+
+To take down the bot, you can run `docker-compose down` in the repository.
 
 ## Technologies
 

--- a/create-env.sh
+++ b/create-env.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+read -p "Bot token >> " token
+read -p "Owner ID >> " owner_id
+
+{
+  echo "TOKEN=$token"
+  echo "OWNERID=$owner_id"
+} > ./.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.8"
+
+services:
+  bot:
+    build:
+      context: "."
+      dockerfile: Dockerfile
+    env_file: 
+      - .env
+    container_name: "Chronos"


### PR DESCRIPTION
- Add `create-env.sh` script to generate `.env` file automatically
- Add `docker-compose.yml` to use and run the bot including the `.env` file