### PR TITLE
Add: RoleInhibitor to restrict bot usage

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 const { config } = require('dotenv');
-const { AkairoClient, CommandHandler, ListenerHandler } = require('discord-akairo');
+const { AkairoClient, CommandHandler, ListenerHandler, InhibitorHandler } = require('discord-akairo');
 const { join } = require('path');
 
 config();
@@ -28,9 +28,15 @@ class ChronosClient extends AkairoClient {
       directory: join(__dirname, 'listeners'),
     });
 
+    this.inhibitorHandler = new InhibitorHandler(this, {
+      directory: join(__dirname, 'inhibitors'),
+    });
+
     this.commandHandler.useListenerHandler(this.listnerHandler);
+    this.commandHandler.useInhibitorHandler(this.inhibitorHandler);
 
     this.listnerHandler.loadAll();
+    this.inhibitorHandler.loadAll();
     this.commandHandler.loadAll();
   }
 }

--- a/src/inhibitors/RoleInhibitor.js
+++ b/src/inhibitors/RoleInhibitor.js
@@ -9,9 +9,10 @@ class RoleInhibitor extends Inhibitor {
   }
 
   exec(message) {
-    const guildConfiguration = config.guildConfigurations.find(el => el.guildID == message.guild.id);
+    if (config.guildConfigurations.length === 0) return false; // No guild has been added so allow all commands
 
-    return !message.member.roles.cache.has(guildConfiguration.staffRole);
+    const guildConfiguration = config.guildConfigurations.find(el => el.guildID === parseInt(message.guild.id, 10));
+    return !(guildConfiguration !== undefined && message.member.roles.cache.has(guildConfiguration.staffRole));
   }
 }
 

--- a/src/inhibitors/RoleInhibitor.js
+++ b/src/inhibitors/RoleInhibitor.js
@@ -1,0 +1,21 @@
+const { Inhibitor } = require('discord-akairo');
+const config = require('../../config.json');
+
+class RoleInhibitor extends Inhibitor {
+  constructor() {
+    super('no_role', {
+      reason: 'member does not have staff role',
+    });
+  }
+
+  exec(message) {
+    console.log('executing inhibitor');
+    console.log('config', config);
+    const guildConfiguration = config.guildConfigurations.find(el => el.guildID === message.guild.id);
+    console.log(guildConfiguration);
+
+    return !message.member.roles.cache.has(guildConfiguration.staffRole);
+  }
+}
+
+module.exports = RoleInhibitor;

--- a/src/inhibitors/RoleInhibitor.js
+++ b/src/inhibitors/RoleInhibitor.js
@@ -9,10 +9,7 @@ class RoleInhibitor extends Inhibitor {
   }
 
   exec(message) {
-    console.log('executing inhibitor');
-    console.log('config', config);
-    const guildConfiguration = config.guildConfigurations.find(el => el.guildID === message.guild.id);
-    console.log(guildConfiguration);
+    const guildConfiguration = config.guildConfigurations.find(el => el.guildID == message.guild.id);
 
     return !message.member.roles.cache.has(guildConfiguration.staffRole);
   }


### PR DESCRIPTION
Used Akairo's inhibitors to restrict bot commands usage to staff role
only. The staff role is fetched from config.json file.

Note: Inhibitors need to return FALSE to ALLOW command processing.

Possible Improvements:
- Utility to read config.json files instead of require()
- Response if the inhibitors blocked command processing.

Inhibitors don't seem to have an option to set response for blocked
messages, which might mean to not use inhibitors if a response is necessary.

Fixes #4